### PR TITLE
Ot97 74/peticiones get a los endpoints públicos de la api de forma centralizada

### DIFF
--- a/src/app/features/backoffice/pages/slide/slide.component.ts
+++ b/src/app/features/backoffice/pages/slide/slide.component.ts
@@ -8,6 +8,7 @@ import { ImageFile } from 'src/app/features/models/ImageFile';
 import { Slide } from 'src/app/features/public/models/slide';
 import { environment } from 'src/environments/environment';
 import Swal from 'sweetalert2';
+import { PrivateBackofficeService } from '../../services/private-backoffice.service';
 
 @Component({
   selector: 'app-slide',
@@ -37,7 +38,8 @@ export class SlideComponent implements OnInit {
     private router: Router,
     private route: ActivatedRoute,
     private httpService: HttpService,
-    private ckeditorSvc: CkeditorService
+    private ckeditorSvc: CkeditorService,
+    private backofficeServices: PrivateBackofficeService
   ) {
     this.form = this._builder.group({
       name: ["", [Validators.required]],

--- a/src/app/features/backoffice/services/private-backoffice.service.ts
+++ b/src/app/features/backoffice/services/private-backoffice.service.ts
@@ -1,10 +1,25 @@
 import { Injectable } from '@angular/core';
+import { HttpService } from 'src/app/core/services/http.service';
+import { Data } from '../../models/data';
 
 @Injectable({
   providedIn: 'root'
 })
 export class PrivateBackofficeService {
 
-constructor() { }
+constructor(private servicesHttp:HttpService) {
+ 
+ }
+
+
+public putPrivate(endPoint:string, data:Data, authorizacion:boolean){
+  if(authorizacion){
+    return this.servicesHttp.put(endPoint, data, authorizacion)
+  }else{
+    return console.log('necesita enviar el token para hacer la peticion')
+  }
+ }
+
 
 }
+

--- a/src/app/features/backoffice/services/private-backoffice.service.ts
+++ b/src/app/features/backoffice/services/private-backoffice.service.ts
@@ -16,7 +16,7 @@ export class PrivateBackofficeService {
 
 
 public putPrivate(url:string, id:string,  data:Data, authorizacion:boolean):Observable<HttpResponse<Activity>>{
- this.httpService.setHeaders("Authorization", this.userStatusService.getHeaders());         
+ this.httpService.setHeaders("Authorization", this.userStatusService.getHeaders());      
     return this.httpService.put(url+'/'+id , data, true )
   
  }

--- a/src/app/features/models/data.ts
+++ b/src/app/features/models/data.ts
@@ -1,0 +1,16 @@
+
+export interface Data {
+    id?:          number;
+    name?:        string;
+    slug?:        string;
+    description?: string;
+    image?:       string;
+    user_id?:     number;
+    category_id?: number;
+    created_at?:  Date;
+    updated_at?:  Date;
+    deleted_at?:  Date;
+    facebookUrl?: string;
+    linkedinUrl?: string;
+    content?: string;
+}

--- a/src/app/features/public/services/public.service.ts
+++ b/src/app/features/public/services/public.service.ts
@@ -1,10 +1,14 @@
 import { Injectable } from '@angular/core';
+import { HttpService } from 'src/app/core/services/http.service';
 
 @Injectable({
   providedIn: 'root'
 })
 export class PublicService {
 
-constructor() { }
+constructor(private httpServices:HttpService) { }
 
+public getPublic(url:string, id?:string){
+  return this.httpServices.get(url+'/'+id, false  )
+}
 }


### PR DESCRIPTION
en el servicio public se creo un metodo reutilizable para hacer peticiones get por medio del services core, dicho metodo recibe por parametros la ruta de destino y un id que es opcional, los cuales se concatenan